### PR TITLE
모든 페이지에서 로그인 유저 정보 보기

### DIFF
--- a/src/main/java/com/been/catego/controller/HomeController.java
+++ b/src/main/java/com/been/catego/controller/HomeController.java
@@ -26,8 +26,6 @@ public class HomeController {
         WithPageTokenResponse<List<ChannelWithFolderNamesResponse>> result =
                 channelService.findSubscriptionChannelsWithFolderNames(principalDetails.getId(), pageToken, 10);
 
-        model.addAttribute("profileImageUrl", principalDetails.getProfileImageUrl());
-        model.addAttribute("nickname", principalDetails.getNickname());
         model.addAttribute("channels", result.data());
         model.addAttribute("pageToken", result.pageToken());
 

--- a/src/main/resources/templates/layout/header.html
+++ b/src/main/resources/templates/layout/header.html
@@ -14,9 +14,10 @@
             </a>
 
             <div class="text-end d-flex align-items-center justify-content-between">
-                <img src="https://github.com/mdo.png" th:src="${profileImageUrl}" alt="mdo" width="32" height="32"
-                     class="rounded-circle me-2">
-                <div class="me-2" th:text="${nickname}">
+                <img src="https://github.com/mdo.png" th:src="${#authentication.principal.profileImageUrl}"
+                     alt="profileUrl"
+                     width="32" height="32" class="rounded-circle me-2">
+                <div class="me-2" th:text="${#authentication.principal.nickname}">
                     hyebeen
                 </div>
                 <form th:action="@{/logout}" method="post">


### PR DESCRIPTION
원래는 `/` 접근 시에만 유저 닉네임, 프로필 사진이 표시되었다.
모든 접근에 정보를 표시하기 위해 타임리프 문법을 사용해 해당 버그를 해결한다.