### PR TITLE
YouTube API Quota Cost 줄이기: Search 사용하지 않기

### DIFF
--- a/src/main/java/com/been/catego/service/ChannelService.java
+++ b/src/main/java/com/been/catego/service/ChannelService.java
@@ -12,7 +12,7 @@ import com.been.catego.exception.ErrorMessages;
 import com.been.catego.repository.FolderChannelRepository;
 import com.been.catego.repository.FolderRepository;
 import com.google.api.services.youtube.model.Channel;
-import com.google.api.services.youtube.model.SearchListResponse;
+import com.google.api.services.youtube.model.PlaylistItemListResponse;
 import com.google.api.services.youtube.model.SubscriptionListResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -57,13 +57,14 @@ public class ChannelService {
 
     public WithPageTokenResponse<List<VideoResponse>> getVideosForChannel(String channelId, int maxResult,
                                                                           String pageToken) {
-        SearchListResponse searchListResponse =
-                youTubeApiService.searchVideosByChannelId(channelId, maxResult, pageToken);
+        PlaylistItemListResponse playlistItemListResponse =
+                youTubeApiService.getVideosByChannelId(channelId, maxResult, pageToken);
 
-        PageTokenResponse pageTokenResponse = new PageTokenResponse(searchListResponse.getPrevPageToken(),
-                searchListResponse.getNextPageToken());
+        PageTokenResponse pageTokenResponse = new PageTokenResponse(playlistItemListResponse.getPrevPageToken(),
+                playlistItemListResponse.getNextPageToken());
 
-        List<VideoResponse> data = youTubeApiService.getVideosByVideoIds(convertToVideoIds(searchListResponse)).stream()
+        List<VideoResponse> data = youTubeApiService.getVideosByIds(convertToVideoIds(playlistItemListResponse))
+                .stream()
                 .map(VideoResponse::from)
                 .toList();
         return new WithPageTokenResponse<>(data, pageTokenResponse);

--- a/src/main/java/com/been/catego/util/YoutubeConvertUtils.java
+++ b/src/main/java/com/been/catego/util/YoutubeConvertUtils.java
@@ -1,8 +1,8 @@
 package com.been.catego.util;
 
 import com.google.api.client.util.DateTime;
+import com.google.api.services.youtube.model.PlaylistItemListResponse;
 import com.google.api.services.youtube.model.ResourceId;
-import com.google.api.services.youtube.model.SearchListResponse;
 import com.google.api.services.youtube.model.Subscription;
 import com.google.api.services.youtube.model.SubscriptionListResponse;
 import com.google.api.services.youtube.model.SubscriptionSnippet;
@@ -35,9 +35,15 @@ public final class YoutubeConvertUtils {
                 .toList();
     }
 
-    public static List<String> convertToVideoIds(SearchListResponse searchListResponse) {
-        return searchListResponse.getItems().stream()
-                .map(searchResult -> searchResult.getId().getVideoId())
+    public static List<String> convertToVideoIds(PlaylistItemListResponse playlistItemListResponse) {
+        return playlistItemListResponse.getItems().stream()
+                .map(playlistItem -> playlistItem.getSnippet().getResourceId().getVideoId())
                 .toList();
+    }
+
+    public static String convertToUploadPlaylistId(String channelId) {
+        char[] chars = channelId.toCharArray();
+        chars[1] = 'U';
+        return new String(chars);
     }
 }


### PR DESCRIPTION
`Search.List`의 cost는 무려 100이다.
채널의 영상을 가져올 때 `Search.List` 대신 `PlaylistItems.List`를 사용해서 quota cost를 줄인다.