### PR TITLE
사이드 바에서 폴더를 볼 때 채널 이름순으로 정렬되게 수정

### DIFF
--- a/src/main/java/com/been/catego/repository/FolderChannelRepository.java
+++ b/src/main/java/com/been/catego/repository/FolderChannelRepository.java
@@ -12,6 +12,7 @@ public interface FolderChannelRepository extends JpaRepository<FolderChannel, Lo
     @Query("select fc from FolderChannel fc "
             + "join fetch fc.folder f "
             + "join fetch fc.channel c "
-            + "where f.id in :folderIds")
+            + "where f.id in :folderIds "
+            + "order by c.name")
     List<FolderChannel> findAllByFolderIdIn(@Param("folderIds") List<Long> folderIds);
 }


### PR DESCRIPTION
사이드바에서 폴더를 볼 때 채널 이름순으로 정렬되지 않는 버그를 발견하고 이를 수정한다.