### PR TITLE
fix: 구독 채널이 속한 폴더가 표시될 때 폴더가 이름순으로 정렬되게 수정

### DIFF
--- a/src/main/java/com/been/catego/repository/FolderRepository.java
+++ b/src/main/java/com/been/catego/repository/FolderRepository.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 
 public interface FolderRepository extends JpaRepository<Folder, Long> {
 
+    List<Folder> findAllByUser_Id(Long userId);
+
     List<Folder> findAllByUser_IdOrderByNameAsc(Long userId);
 
     @Query("select f From Folder f " +

--- a/src/main/java/com/been/catego/service/ChannelService.java
+++ b/src/main/java/com/been/catego/service/ChannelService.java
@@ -85,7 +85,7 @@ public class ChannelService {
 
     private List<ChannelWithFolderNamesResponse> getChannelWithFolderNamesSortedByChannelTitle(Long userId,
                                                                                                List<Channel> youTubeChannels) {
-        List<Folder> folders = folderRepository.findAllByUser_IdOrderByNameAsc(userId);
+        List<Folder> folders = folderRepository.findAllByUser_Id(userId);
         Map<String, List<FolderChannel>> channelIdToFolderChannelsMap =
                 getChannelIdToFolderChannelsMap(toFolderIds(folders));
 
@@ -105,6 +105,7 @@ public class ChannelService {
 
         return channelToFolderChannelsMap.get(youTubeChannel.getId()).stream()
                 .map(FolderChannel::getFolder)
+                .sorted(Comparator.comparing(Folder::getName, String.CASE_INSENSITIVE_ORDER))
                 .toList();
     }
 


### PR DESCRIPTION
홈에서 구독 채널과 해당 채널이 속한 폴더가 표시되는데, 폴더가 이름순으로 정렬되게 수정한다.