### PR TITLE
fix: google login 시 발생하는 redirect_uri_mismatch 오류 해결

### DIFF
--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -2,6 +2,15 @@ logging:
   level:
     org.hibernate.SQL: debug
 
+server:
+  forward-headers-strategy: framework
+  tomcat:
+    remoteip:
+      remote-ip-header: X-Forwarded-For
+      protocol-header: X-Forwarded-Proto
+      host-header: X-Forwarded-Host
+      port-header: X-Forwarded-Port
+
 spring:
   datasource:
     url: jdbc:mysql://${DB_HOST}:3306/${DB_NAME}?useSSL=false&useUnicode=true&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true


### PR DESCRIPTION
https가 아닌 http로 요청해서 오류가 발생했다.

`X-Forwarded-*` 헤더를 이용하여 최초 요청 정보를 담아 해결한다.